### PR TITLE
Bump Hugo from 0.151.0 to 0.160.1

### DIFF
--- a/.github/workflows/hugo.yml
+++ b/.github/workflows/hugo.yml
@@ -33,7 +33,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     env:
-      HUGO_VERSION: 0.151.0
+      HUGO_VERSION: 0.160.1
       HUGO_ENVIRONMENT: production
       TZ: America/Los_Angeles
     steps:


### PR DESCRIPTION
## Summary

- Update Hugo version from 0.151.0 to 0.160.1 in CI workflow
- Includes bug fixes for passthrough elements, template name handling,
  RenderShortcodes context markers, and multilingual root sections

## Test plan

- [ ] CI build passes with the new Hugo version
- [ ] Site renders correctly on the deployed preview