### PR TITLE
Fix docs index: link reporting tutorial

### DIFF
--- a/content/docs/_index.md
+++ b/content/docs/_index.md
@@ -8,4 +8,4 @@ These docs consist of the following parts:
 1. [Query](/docs/query)
 2. [API](/docs/api)
 3. [User](/docs/user)
-4. Reporting (Coming soon)
+4. [Reporting](/tutorials/reporting)


### PR DESCRIPTION
## Summary

- Replace "Reporting (Coming soon)" with a link to the existing
  reporting tutorial at /tutorials/reporting

## Test plan

- [ ] CI build passes
- [ ] Docs index page shows a clickable link to the reporting tutorial